### PR TITLE
Fix leads API timeout due to unbuffered channels

### DIFF
--- a/Client/app/dashboard/contributions/new/page.tsx
+++ b/Client/app/dashboard/contributions/new/page.tsx
@@ -74,10 +74,14 @@ const RequestScreen = () => {
     useGetClubInfoQuery(clubId);
   const { data: departmentsData, isLoading: isDepartmentsLoading } =
     useGetAllClubDepartmentsQuery(clubId);
-  const { data: leadsData, isLoading: isLeadsLoading } =
-    useGetDepartmentLeadsQuery(selectedDepartmentId, {
-      skip: !selectedDepartmentId,
-    });
+  const {
+    data: leadsData,
+    isLoading: isLeadsLoading,
+    isError: isLeadsError,
+    error: leadsError,
+  } = useGetDepartmentLeadsQuery(selectedDepartmentId, {
+    skip: !selectedDepartmentId,
+  });
   const { data: tasksData, isLoading: isTasksLoading } =
     useGetTasksByDepartmentIDQuery(selectedDepartmentId, {
       skip: !selectedDepartmentId,
@@ -119,14 +123,17 @@ const RequestScreen = () => {
 
   // Update available leads when department or leads data changes
   useEffect(() => {
-    if (leadsData?.leads) {
-      const filteredLeads = leadsData.leads.filter(
+    if (leadsData) {
+      const leads = leadsData.leads || [];
+      const filteredLeads = leads.filter(
         (lead) =>
           !selectedLeads.some((selected) => selected.user_id === lead.user_id)
       );
       setAvailableLeads(filteredLeads);
+    } else {
+      setAvailableLeads([]);
     }
-  }, [leadsData?.leads, selectedLeads]);
+  }, [leadsData, selectedLeads]);
 
   const addLead = () => {
     if (!selectedLead) {
@@ -360,6 +367,14 @@ const RequestScreen = () => {
                         {isLeadsLoading ? (
                           <SelectItem value="loading" disabled>
                             Loading leads...
+                          </SelectItem>
+                        ) : isLeadsError ? (
+                          <SelectItem value="error" disabled>
+                            Error loading leads
+                          </SelectItem>
+                        ) : availableLeads.length === 0 ? (
+                          <SelectItem value="empty" disabled>
+                            No leads available
                           </SelectItem>
                         ) : (
                           availableLeads.map((lead) => (

--- a/Server/api/controllers/dept_controllers.go
+++ b/Server/api/controllers/dept_controllers.go
@@ -65,8 +65,13 @@ func GetDepartmentLeadsByID(id string) ([]types.LeadsInfo, error) {
 		return []types.LeadsInfo{}, err
 	}
 
-	var leadChan = make(chan types.LeadsInfo)
-	var errChan = make(chan error)
+	// If no leads, return empty array
+	if len(dept.Leads) == 0 {
+		return []types.LeadsInfo{}, nil
+	}
+
+	var leadChan = make(chan types.LeadsInfo, len(dept.Leads))
+	var errChan = make(chan error, len(dept.Leads))
 	var wg sync.WaitGroup
 
 	for _, leadUserID := range dept.Leads {
@@ -94,9 +99,13 @@ func GetDepartmentLeadsByID(id string) ([]types.LeadsInfo, error) {
 		leadsData = append(leadsData, lead)
 	}
 
+	// Check for errors after collecting successful results
 	if len(errChan) > 0 {
 		err := <-errChan
 		log.Printf("error fetching lead user data: %v", err)
+		if len(leadsData) > 0 {
+			return leadsData, nil
+		}
 		return []types.LeadsInfo{}, err
 	}
 	return leadsData, nil


### PR DESCRIPTION
Fix goroutine deadlock in department leads API and improve error handling

Backend changes:
- Fix unbuffered channel deadlock in GetDepartmentLeadsByID causing API timeout
- Add buffered channels (capacity = len(dept.Leads)) to prevent blocking
- Add empty leads array check to avoid unnecessary goroutine spawning
- Return partial results when some user fetches fail
- Remove verbose debug logs added during troubleshooting
- Update Go dependencies (resend-go moved to direct, removed gomail)

Frontend changes:
- Add error state handling (isLeadsError, error) for leads API query
- Improve leads dropdown UI with error/empty/loading states
- Fix leads data safety check in useEffect (handle undefined)

This resolves the issue where selecting a department in /dashboard/contributions/new 
would show "Loading leads..." indefinitely due to backend goroutine deadlock.